### PR TITLE
Enable CMS translations

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -197,11 +197,11 @@ collections:
   - name: "translations"
     label: "多语言翻译"
     files:
-      - label: "中文翻译"
-        name: "zh_translations"
-        file: "src/i18n/resources/zh/cms.json"
-        fields:
-          - label: "导航菜单"
+        - label: "中文翻译"
+          name: "zh_translations"
+          file: "src/i18n/resources/zh/cms.json"
+          fields:
+            - label: "导航菜单"
             name: "navigation"
             widget: "object"
             fields:
@@ -210,21 +210,46 @@ collections:
               - { label: "服务内容", name: "services", widget: "string", default: "服务内容" }
               - { label: "新闻动态", name: "news", widget: "string", default: "新闻动态" }
               - { label: "联系我们", name: "contact", widget: "string", default: "联系我们" }
-          
-          - label: "页面标题"
-            name: "pageTitle"
-            widget: "object"
-            fields:
-              - { label: "关于我们", name: "about", widget: "string", default: "关于我们" }
-              - { label: "服务内容", name: "services", widget: "string", default: "服务内容" }
-              - { label: "新闻动态", name: "news", widget: "string", default: "新闻动态" }
-              - { label: "联系我们", name: "contact", widget: "string", default: "联系我们" }
 
-      - label: "日语翻译"
-        name: "ja_translations"
-        file: "src/i18n/resources/ja/cms.json"
-        fields:
-          - label: "導航メニュー"
+            - label: "页面标题"
+              name: "pageTitle"
+              widget: "object"
+              fields:
+                - { label: "关于我们", name: "about", widget: "string", default: "关于我们" }
+                - { label: "服务内容", name: "services", widget: "string", default: "服务内容" }
+                - { label: "新闻动态", name: "news", widget: "string", default: "新闻动态" }
+                - { label: "联系我们", name: "contact", widget: "string", default: "联系我们" }
+
+            - label: "页脚"
+              name: "footer"
+              widget: "object"
+              fields:
+                - { label: "快速链接", name: "quickLinks", widget: "string", default: "快速链接" }
+                - { label: "联系方式", name: "contact", widget: "string", default: "联系方式" }
+                - { label: "业务内容", name: "business", widget: "string", default: "业务内容" }
+                - label: "联系方式子项"
+                  name: "contactItems"
+                  widget: "object"
+                  fields:
+                    - { label: "邮箱", name: "email", widget: "string", default: "邮箱" }
+                    - { label: "电话", name: "phone", widget: "string", default: "电话" }
+                    - { label: "地址", name: "address", widget: "string", default: "地址" }
+                    - { label: "营业时间", name: "hours", widget: "string", default: "营业时间" }
+                - label: "底部链接"
+                  name: "links"
+                  widget: "object"
+                  fields:
+                    - { label: "隐私政策", name: "privacy", widget: "string", default: "隐私政策" }
+                    - { label: "使用条款", name: "terms", widget: "string", default: "使用条款" }
+                    - { label: "网站地图", name: "sitemap", widget: "string", default: "网站地图" }
+                - { label: "标语", name: "tagline", widget: "string", default: "专业的中日贸易综合服务商" }
+                - { label: "版权后缀", name: "builtWith", widget: "string", default: "Built with ❤️ for connecting China and Japan" }
+
+        - label: "日语翻译"
+          name: "ja_translations"
+          file: "src/i18n/resources/ja/cms.json"
+          fields:
+            - label: "導航メニュー"
             name: "navigation"
             widget: "object"
             fields:
@@ -234,11 +259,45 @@ collections:
               - { label: "ニュース", name: "news", widget: "string", default: "ニュース" }
               - { label: "お問い合わせ", name: "contact", widget: "string", default: "お問い合わせ" }
 
-      - label: "英语翻译"
-        name: "en_translations"
-        file: "src/i18n/resources/en/cms.json"
-        fields:
-          - label: "Navigation Menu"
+            - label: "ページタイトル"
+              name: "pageTitle"
+              widget: "object"
+              fields:
+                - { label: "会社概要", name: "about", widget: "string", default: "会社概要" }
+                - { label: "事業内容", name: "services", widget: "string", default: "事業内容" }
+                - { label: "ニュース", name: "news", widget: "string", default: "ニュース" }
+                - { label: "お問い合わせ", name: "contact", widget: "string", default: "お問い合わせ" }
+
+            - label: "フッター"
+              name: "footer"
+              widget: "object"
+              fields:
+                - { label: "クイックリンク", name: "quickLinks", widget: "string", default: "クイックリンク" }
+                - { label: "連絡先", name: "contact", widget: "string", default: "連絡先" }
+                - { label: "事業内容", name: "business", widget: "string", default: "事業内容" }
+                - label: "連絡項目"
+                  name: "contactItems"
+                  widget: "object"
+                  fields:
+                    - { label: "メール", name: "email", widget: "string", default: "メール" }
+                    - { label: "電話", name: "phone", widget: "string", default: "電話" }
+                    - { label: "住所", name: "address", widget: "string", default: "住所" }
+                    - { label: "営業時間", name: "hours", widget: "string", default: "営業時間" }
+                - label: "リンク"
+                  name: "links"
+                  widget: "object"
+                  fields:
+                    - { label: "プライバシー", name: "privacy", widget: "string", default: "プライバシーポリシー" }
+                    - { label: "利用規約", name: "terms", widget: "string", default: "利用規約" }
+                    - { label: "サイトマップ", name: "sitemap", widget: "string", default: "サイトマップ" }
+                - { label: "タグライン", name: "tagline", widget: "string", default: "日中貿易の総合サービスプロバイダー" }
+                - { label: "ビルド情報", name: "builtWith", widget: "string", default: "Built with ❤️ for connecting China and Japan" }
+
+        - label: "英语翻译"
+          name: "en_translations"
+          file: "src/i18n/resources/en/cms.json"
+          fields:
+            - label: "Navigation Menu"
             name: "navigation"
             widget: "object"
             fields:
@@ -247,3 +306,37 @@ collections:
               - { label: "Services", name: "services", widget: "string", default: "Services" }
               - { label: "News", name: "news", widget: "string", default: "News" }
               - { label: "Contact", name: "contact", widget: "string", default: "Contact" }
+
+            - label: "Page Titles"
+              name: "pageTitle"
+              widget: "object"
+              fields:
+                - { label: "About", name: "about", widget: "string", default: "About Us" }
+                - { label: "Services", name: "services", widget: "string", default: "Services" }
+                - { label: "News", name: "news", widget: "string", default: "News" }
+                - { label: "Contact", name: "contact", widget: "string", default: "Contact" }
+
+            - label: "Footer"
+              name: "footer"
+              widget: "object"
+              fields:
+                - { label: "Quick Links", name: "quickLinks", widget: "string", default: "Quick Links" }
+                - { label: "Contact Section", name: "contact", widget: "string", default: "Contact Information" }
+                - { label: "Business Section", name: "business", widget: "string", default: "Business Services" }
+                - label: "Contact Items"
+                  name: "contactItems"
+                  widget: "object"
+                  fields:
+                    - { label: "Email", name: "email", widget: "string", default: "Email" }
+                    - { label: "Phone", name: "phone", widget: "string", default: "Phone" }
+                    - { label: "Address", name: "address", widget: "string", default: "Address" }
+                    - { label: "Hours", name: "hours", widget: "string", default: "Business Hours" }
+                - label: "Legal Links"
+                  name: "links"
+                  widget: "object"
+                  fields:
+                    - { label: "Privacy", name: "privacy", widget: "string", default: "Privacy Policy" }
+                    - { label: "Terms", name: "terms", widget: "string", default: "Terms of Service" }
+                    - { label: "Sitemap", name: "sitemap", widget: "string", default: "Sitemap" }
+                - { label: "Tagline", name: "tagline", widget: "string", default: "Professional China-Japan Trade Service Provider" }
+                - { label: "Built With", name: "builtWith", widget: "string", default: "Built with ❤️ for connecting China and Japan" }

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -6,11 +6,32 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import zhResources from './resources/zh';
 import jaResources from './resources/ja';
 import enResources from './resources/en';
+import zhCms from './resources/zh/cms.json';
+import jaCms from './resources/ja/cms.json';
+import enCms from './resources/en/cms.json';
+
+const deepMerge = (target, source) => {
+  const result = { ...target };
+  for (const key in source) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      if (
+        source[key] &&
+        typeof source[key] === 'object' &&
+        !Array.isArray(source[key])
+      ) {
+        result[key] = deepMerge(result[key] || {}, source[key]);
+      } else {
+        result[key] = source[key];
+      }
+    }
+  }
+  return result;
+};
 
 const resources = {
-  zh: { translation: zhResources },
-  ja: { translation: jaResources },
-  en: { translation: enResources }
+  zh: { translation: deepMerge(zhResources, zhCms) },
+  ja: { translation: deepMerge(jaResources, jaCms) },
+  en: { translation: deepMerge(enResources, enCms) }
 };
 
 // 初始化 i18n

--- a/src/i18n/resources/en/cms.json
+++ b/src/i18n/resources/en/cms.json
@@ -1,0 +1,33 @@
+{
+  "navigation": {
+    "home": "Home",
+    "about": "About Us",
+    "services": "Services",
+    "news": "News",
+    "contact": "Contact"
+  },
+  "pageTitle": {
+    "about": "About Us",
+    "services": "Services",
+    "news": "News",
+    "contact": "Contact"
+  },
+  "footer": {
+    "quickLinks": "Quick Links",
+    "contact": "Contact Information",
+    "business": "Business Services",
+    "contactItems": {
+      "email": "Email",
+      "phone": "Phone",
+      "address": "Address",
+      "hours": "Business Hours"
+    },
+    "links": {
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Service",
+      "sitemap": "Sitemap"
+    },
+    "tagline": "Professional China-Japan Trade Service Provider",
+    "builtWith": "Built with ❤️ for connecting China and Japan"
+  }
+}

--- a/src/i18n/resources/ja/cms.json
+++ b/src/i18n/resources/ja/cms.json
@@ -1,0 +1,33 @@
+{
+  "navigation": {
+    "home": "ホーム",
+    "about": "会社概要",
+    "services": "事業内容",
+    "news": "ニュース",
+    "contact": "お問い合わせ"
+  },
+  "pageTitle": {
+    "about": "会社概要",
+    "services": "事業内容",
+    "news": "ニュース",
+    "contact": "お問い合わせ"
+  },
+  "footer": {
+    "quickLinks": "クイックリンク",
+    "contact": "連絡先",
+    "business": "事業内容",
+    "contactItems": {
+      "email": "メール",
+      "phone": "電話",
+      "address": "住所",
+      "hours": "営業時間"
+    },
+    "links": {
+      "privacy": "プライバシーポリシー",
+      "terms": "利用規約",
+      "sitemap": "サイトマップ"
+    },
+    "tagline": "日中貿易の総合サービスプロバイダー",
+    "builtWith": "Built with ❤️ for connecting China and Japan"
+  }
+}

--- a/src/i18n/resources/zh/cms.json
+++ b/src/i18n/resources/zh/cms.json
@@ -1,0 +1,33 @@
+{
+  "navigation": {
+    "home": "首页",
+    "about": "关于我们",
+    "services": "服务内容",
+    "news": "新闻动态",
+    "contact": "联系我们"
+  },
+  "pageTitle": {
+    "about": "关于我们",
+    "services": "服务内容",
+    "news": "新闻动态",
+    "contact": "联系我们"
+  },
+  "footer": {
+    "quickLinks": "快速链接",
+    "contact": "联系方式",
+    "business": "业务内容",
+    "contactItems": {
+      "email": "邮箱",
+      "phone": "电话",
+      "address": "地址",
+      "hours": "营业时间"
+    },
+    "links": {
+      "privacy": "隐私政策",
+      "terms": "使用条款",
+      "sitemap": "网站地图"
+    },
+    "tagline": "专业的中日贸易综合服务商",
+    "builtWith": "Built with ❤️ for connecting China and Japan"
+  }
+}


### PR DESCRIPTION
## Summary
- load `cms.json` files for each locale so CMS managers can edit translations
- default translation sets in `cms.json` for Chinese, English and Japanese
- add footer and page title fields to CMS config

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e487ee5c08320907697ba0ad166c2