### PR TITLE
Add multilingual CMS data support

### DIFF
--- a/docs/i18n-guide.md
+++ b/docs/i18n-guide.md
@@ -26,6 +26,7 @@ Currently supported language codes:
 
 1. Copy the original Chinese markdown file to the appropriate language folder.
 2. Translate the front matter fields and the body text.
-3. Run `npm run generate-cms` to regenerate the JSON files under `public/api/`.
+3. Run `npm run generate-cms` to regenerate CMS JSON files under `public/api/`.
+4. Run `npm run generate-news` to rebuild multilingual news indexes.
 
 The hooks in `src/hooks/useCMSContent.js` will automatically load `/api/<path>.<lang>.json` if it exists, falling back to the default file when a translation is missing.

--- a/src/hooks/useNewsArticles.js
+++ b/src/hooks/useNewsArticles.js
@@ -1,5 +1,6 @@
 // src/hooks/useNewsArticles.js
 import { useState, useEffect } from 'react';
+import i18n from '../i18n';
 
 export const useNewsArticles = () => {
   const [articles, setArticles] = useState([]);
@@ -12,8 +13,12 @@ export const useNewsArticles = () => {
         setLoading(true);
         setError(null);
         
-        // 尝试从生成的JSON文件加载文章
-        const response = await fetch('/api/news-index.json');
+        // 尝试从生成的JSON文件加载文章，优先使用当前语言
+        const lang = i18n.language || 'zh';
+        let response = await fetch(`/api/news-index.${lang}.json`);
+        if (!response.ok) {
+          response = await fetch('/api/news-index.json');
+        }
         
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## Summary
- support language-specific JSON generation in CMS script
- generate multilingual news indexes
- fetch language-specific news data in hook
- document new workflow for translations

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e54aedcd083208e6e15e5483244c2