### PR TITLE
Add multilingual slogan display

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { trackEvent } from '../utils/Analytics';
 import { useHomeContent } from '../hooks/useCMSContent';
+import { useTranslation } from 'react-i18next';
 
 const Home = ({ dict, lang = 'zh' }) => {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -9,6 +10,7 @@ const Home = ({ dict, lang = 'zh' }) => {
   const heroRef = useRef(null);
   const videoRef = useRef(null);
   const { content: homeContent } = useHomeContent();
+  const { t } = useTranslation();
 
   // 移动端检测
   useEffect(() => {
@@ -188,6 +190,11 @@ const Home = ({ dict, lang = 'zh' }) => {
                   return <span className="hero-text-line">{slogan}</span>;
                 })()}
               </h1>
+              <div className="slogan-translations mt-4 text-sm sm:text-base font-light text-white space-y-1">
+                <p>{t('home.slogan', { lng: 'zh' })}</p>
+                <p>{t('home.slogan', { lng: 'ja' })}</p>
+                <p>{t('home.slogan', { lng: 'en' })}</p>
+              </div>
             </div>
 
           </div>
@@ -231,6 +238,10 @@ const Home = ({ dict, lang = 'zh' }) => {
           display: block;
           margin-bottom: 0.2em;
           position: relative;
+        }
+
+        .slogan-translations p {
+          font-family: 'Montserrat', 'Hiragino Kaku Gothic Pro', 'Noto Sans CJK JP', 'Microsoft YaHei', sans-serif;
         }
 
         /* 响应式优化 */


### PR DESCRIPTION
## Summary
- show the home page slogan in Chinese, Japanese and English
- add accompanying font style

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden from registry.npmmirror.com)*

------
https://chatgpt.com/codex/tasks/task_e_684e85268d848320a86b9fccd63bf4aa