### PR TITLE
Fix dynamic slogan translation

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { trackEvent } from '../utils/Analytics';
 import { useHomeContent } from '../hooks/useCMSContent';
+import { useTranslation } from 'react-i18next';
 
 const Home = ({ dict, lang = 'zh' }) => {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -9,6 +10,7 @@ const Home = ({ dict, lang = 'zh' }) => {
   const heroRef = useRef(null);
   const videoRef = useRef(null);
   const { content: homeContent } = useHomeContent();
+  const { t } = useTranslation();
 
   // 移动端检测
   useEffect(() => {
@@ -175,7 +177,9 @@ const Home = ({ dict, lang = 'zh' }) => {
             }`}>
               <h1 className="tiktok-glow-text text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold text-center">
                 {(() => {
-                  const slogan = homeContent?.hero?.slogan || '上質な製品でユーザーとつながる';
+                  const slogan = t('home.slogan', {
+                    defaultValue: homeContent?.hero?.slogan || '上質な製品でユーザーとつながる'
+                  });
                   const index = slogan.indexOf('で');
                   if (index !== -1) {
                     return (


### PR DESCRIPTION
## Summary
- revert multilingual text lines and import translation hook
- fetch the hero slogan from i18n so it updates when switching languages

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden from registry.npmmirror.com)*

------
https://chatgpt.com/codex/tasks/task_e_684e85268d848320a86b9fccd63bf4aa